### PR TITLE
Install awscli in a way compatible with Python3

### DIFF
--- a/scripts/ecsub/aws.py
+++ b/scripts/ecsub/aws.py
@@ -32,6 +32,23 @@ class InsufficientInstanceCapacity(AWSError):
         self.recommended_azs = recommended_azs
 
 
+DEFAULT_SETUP_CONTAINER_CMD = """sh -c "
+if ! command -v aws > /dev/null; then
+    apt update;
+    if ! command -v curl > /dev/null; then
+        apt install -y --no-install-recommends curl
+    fi
+    if ! command -v unzip > /dev/null; then
+        apt install -y --no-install-recommends unzip
+    fi
+    curl -sS -o "awscliv2.zip" "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+    unzip -q awscliv2.zip
+    ./aws/install
+    rm -rf aws awscliv2.zip
+fi
+aws --version" """
+
+
 class Aws_ecsub_control:
 
     def __init__(self, params, task_num):
@@ -55,7 +72,7 @@ class Aws_ecsub_control:
         self.shell = params["shell"]
         self.setup_container_cmd = params["setup_container_cmd"]
         if self.setup_container_cmd == "":
-            self.setup_container_cmd = "apt update; apt install -y python-pip; pip install awscli --upgrade; aws configure list"
+            self.setup_container_cmd = DEFAULT_SETUP_CONTAINER_CMD
         self.dind = params["dind"]
         self.log_group_name = params["aws_log_group_name"]
         if self.log_group_name == "":

--- a/scripts/ecsub/submit.py
+++ b/scripts/ecsub/submit.py
@@ -847,7 +847,7 @@ class Argments:
         self.image = "python:2.7.14"
         self.use_amazon_ecr = False
         self.shell = "/bin/bash"
-        self.setup_container_cmd = "apt update; apt install -y python-pip; pip install awscli --upgrade; aws configure list"
+        self.setup_container_cmd = ecsub.aws.DEFAULT_SETUP_CONTAINER_CMD
         self.dind = False
         self.script = ""
         self.tasks = ""


### PR DESCRIPTION
**Note**: This PR is only for review and is not intended to be merged.

Currently, when trying to start a container having Python3 installed using `ecsub`, you’ll see an error like the following:

```
...
Unpacking python-pip (20.3.4+dfsg-4) ...
Setting up libpython2.7-stdlib:amd64 (2.7.18-13ubuntu1.1) ...
Setting up python2.7 (2.7.18-13ubuntu1.1) ...
Setting up libpython2-stdlib:amd64 (2.7.18-3) ...
Setting up python2 (2.7.18-3) ...
Setting up python-pkg-resources (44.1.1-1.2) ...
Setting up python-setuptools (44.1.1-1.2) ...
Setting up python-pip (20.3.4+dfsg-4) ...
/bin/bash: line 1: pip: command not found
/bin/bash: line 1: aws: command not found
/bin/bash: line 1: aws: command not found
/bin/bash: /run.sh: No such file or directory
```

This error seems to be caused by the fact that [`ecsub` implicitly installs `python-pip`](https://github.com/chrovis-genomon/ecsub/blob/1a872309e5f33b8dcf4cfe53238a5634c219e8ea/scripts/ecsub/aws.py#L45) to install the AWS CLI when starting a container. Installing `python-pip` behaves differently depending on the version of Python installed in the environment:

- If Python2 is installed: Does nothing
- If Python3 is installed: Removes the `pip3` and `pip` commands and installs the `pip2` command

As a result, it will remove `pip` from the environment where Python3 is installed, and then the succeeding `pip install awscli` will fail due to `"pip: command not found"`.

This PR fixes `ecsub` so that it can start Python3-based containers successfully, not only Python2-based containers.
The overview of the change is as follows:

- If the AWS CLI is already installed in the environment, use it instead of installing the AWS CLI again.
- If the AWS CLI is not installed in the environment, download the AWS CLI installer directly from the official distribution URL and install it.

There are still some concerns about the change. If you have any suggestions, I’d be happy to have comments on them:

- If the environment has `wget` installed, should we use it instead of `curl`?
- Should `DEFAULT_SETUP_CONTAINER_CMD` be moved to an individual script file since it looks somewhat too complicated to be inlined in the Python code
  - In that case, I’m not so familiar with Python to be sure how to bundle that script file with the Python package (in a version-independent manner) ...